### PR TITLE
[PJT3/Nikel] Server : items 서버 라우터 및 임시DB 구축

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,8 +5,8 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var cors = require('cors');
 
-var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
+var itemsRouter = require('./routes/items');
 
 var app = express();
 
@@ -21,8 +21,8 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(cors());
 
-app.use('/', indexRouter);
 app.use('/users', usersRouter);
+app.use('/items', itemsRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/server/database/itemsData.js
+++ b/server/database/itemsData.js
@@ -1,0 +1,472 @@
+let itemsData = [
+  {
+    id: 10001010,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default2.jpeg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default2.jpeg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001001,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 0,
+      235: 0,
+      240: 0,
+      245: 0,
+      250: 0,
+      255: 0,
+      260: 0,
+      265: 0,
+      270: 0,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001002,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001003,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001004,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001005,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001006,
+    images: [
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+      './Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        cord: 'male',
+        title: '남성',
+      },
+      secondary: {
+        cord: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        cord: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      cord: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: './Images/default.jpg',
+          cord: 'red',
+        },
+        {
+          id: 10001011,
+          image: './Images/default.jpg',
+          cord: 'gold',
+        },
+        {
+          id: 10001012,
+          image: './Images/default.jpg',
+          cord: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+]
+
+module.exports = itemsData;
+
+
+
+// let restsData = [];
+
+// const randomer = (src) => {
+//   if (typeof(src) === 'object') {
+//     return src[Math.floor(Math.random() * src.length)]
+//   }
+//   else {
+//     return Math.floor(Math.random() * src) + 1;
+//   }
+// }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET home page. */
-router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Nikel' });
-});
-
-module.exports = router;

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -1,0 +1,54 @@
+var express = require('express');
+var router = express.Router();
+
+const itemsData = require('../database/itemsData');
+
+// List Router
+router.get('/:primary/:secondary/:tertiary', function(req, res) {
+  console.log(req.params)
+  console.log(req.query)
+  const { primary, secondary, tertiary } = req.params
+  let itemList = itemsData.filter((item) => {
+    item.category.primary === primary &&
+    item.category.secondary === secondary &&
+    item.category.tertiary === tertiary
+  })
+  itemList = itemList.slice(0, 20);
+  res.json(itemList);
+});
+
+// List Functions
+const filterByQuery = (filter, list) => {
+  // let newList = list;
+  // const filterObj = {
+  //   type: (type) => {
+  //     const typeList = type.split(',');
+  //     newList = newList.filter(rest => typeList.includes(rest.category.typeEn));
+  //   },
+  //   price: (price) => {
+  //     const priceRange = price.split(',');
+  //     newList = newList.filter(rest => rest.price >= priceRange[0] && rest.price <= priceRange[1]);
+  //   },
+  //   bed: (bed) => {
+  //     newList = newList.filter(rest => rest.mainInfo['bed'] >= bed);
+  //   },
+  //   bedroom: (bedroom) => {
+  //     newList = newList.filter(rest => rest.mainInfo['bedroom'] >= bedroom);
+  //   },
+  //   bathroom: (bathroom) => {
+  //     newList = newList.filter(rest => rest.mainInfo['bathroom'] >= bathroom);
+  //   }
+  // }
+  // for (let key in filter) {
+  //   filterObj[key](filter[key]);
+  // }
+  // return newList;
+}
+
+// Detail Router
+router.get('/detail/:id', function(req, res, next) {
+  const itemDetail = itemsData.find((item) => item.id === Number(req.params.id));
+  res.json(itemDetail);
+});
+
+module.exports = router;


### PR DESCRIPTION
## 개요
Server : items 상품관련 서버 List, Detail 라우터 및 임시DB 구축

## 수정내용
- Router 설정 : /items path에서 itemsRouter 동작, Semantic URL 로직반영(List - category, Detail - id)
- 임시DB 설정 : 기존 mock data 서버 사이드 이동

## 특이사항
- List 페이지(#8) 와 연동 테스트를 위한 선 merge 필요
- 연동 테스트 완료시, DB데이터 다수 랜덤제작 적용 필요(검색, 필터 구현위함)
- 향후, 검색 및 필터로직(Query String), Infinite Scroll(Pagination 응용) 재요청 로직 추가 필요

## 체크리스트
- [x] Main branch 최신화(merge)를 진행했는가?
- [x] 컴포넌트에 필요한 UI구현에 이상이 없는가?
- [x] 기능구현에 필요한 테스트를 진행하였고 이상이 없는가?
- [x] 최종 Push 전 코드 리펙토링을 진행하였는가? (불필요 콘솔 및 주석, 컨벤션, 코드개선 등) 
