### PR TITLE
[PJT3/Nikel] Test : itemList 데이터 연동 테스트

### DIFF
--- a/client/src/Components/Header/HeaderData.js
+++ b/client/src/Components/Header/HeaderData.js
@@ -189,7 +189,7 @@ export const NAV_CATEGORIES = [
       {
         id: 202,
         title: '신발',
-        cord: '',
+        cord: 'shoes',
         tertiary: [
           {
             id: 20201,
@@ -199,7 +199,7 @@ export const NAV_CATEGORIES = [
           {
             id: 20202,
             title: '라이프스타일',
-            cord: '',
+            cord: 'lifestyle',
           },
           {
             id: 20203,

--- a/client/src/Components/Header/HeaderData.js
+++ b/client/src/Components/Header/HeaderData.js
@@ -2,128 +2,128 @@ export const NAV_CATEGORIES = [
   {
     id: 1,
     title: 'New Releases',
-    cord: 'new',
+    code: 'new',
     secondary: [
       {
         id: 101,
         title: 'New & Featured',
-        cord: 'new_featured',
+        code: 'new_featured',
         tertiary: [
           {
             id: 10101,
             title: '신상품 전체보기',
-            cord: 'new',
+            code: 'new',
           },
           {
             id: 10102,
             title: 'SNKRS',
-            cord: '',
+            code: '',
           },
           {
             id: 10103,
             title: '에어맥스 97',
-            cord: '',
+            code: '',
           },
           {
             id: 10104,
             title: '에어 포스 1',
-            cord: '',
+            code: '',
           },
           {
             id: 10105,
             title: 'ACG',
-            cord: '',
+            code: '',
           },
           {
             id: 10106,
             title: 'NikeLab',
-            cord: '',
+            code: '',
           },
           {
             id: 10107,
             title: 'SALE: 아우터웨어',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 102,
         title: 'New For Man',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 10201,
             title: '신발',
-            cord: '',
+            code: '',
           },
           {
             id: 10202,
             title: '의류',
-            cord: '',
+            code: '',
           },
           {
             id: 10203,
             title: '용품',
-            cord: '',
+            code: '',
           },
           {
             id: 10204,
             title: '전체보기',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 103,
         title: 'New For Woman',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 10301,
             title: '신발',
-            cord: '',
+            code: '',
           },
           {
             id: 10302,
             title: '의류',
-            cord: '',
+            code: '',
           },
           {
             id: 10303,
             title: '용품',
-            cord: '',
+            code: '',
           },
           {
             id: 10304,
             title: '전체보기',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 104,
         title: 'New For Kids',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 10401,
             title: '신발',
-            cord: '',
+            code: '',
           },
           {
             id: 10402,
             title: '의류',
-            cord: '',
+            code: '',
           },
           {
             id: 10403,
             title: '용품',
-            cord: '',
+            code: '',
           },
           {
             id: 10404,
             title: '전체보기',
-            cord: '',
+            code: '',
           },
         ]
       },
@@ -132,245 +132,245 @@ export const NAV_CATEGORIES = [
   {
     id: 2,
     title: 'Men',
-    cord: 'male',
+    code: 'male',
     secondary: [
       {
         id: 201,
         title: 'New & Featured',
-        cord: 'new_featured',
+        code: 'new_featured',
         tertiary: [
           {
             id: 20101,
             title: '신상품',
-            cord: 'new',
+            code: 'new',
           },
           {
             id: 20102,
             title: 'SNKRS',
-            cord: 'snkrs',
+            code: 'snkrs',
           },
           {
             id: 20103,
             title: 'THE BEST',
-            cord: 'best',
+            code: 'best',
           },
           {
             id: 20104,
             title: 'MEMBER SHOP',
-            cord: 'member_shop',
+            code: 'member_shop',
           },
           {
             id: 20105,
             title: '윈터웨어 컬렉션',
-            cord: 'winter',
+            code: 'winter',
           },
           {
             id: 20106,
             title: '줌 X 인빈서블 런 플라이니트',
-            cord: 'flyneat',
+            code: 'flyneat',
           },
           {
             id: 20107,
             title: '젠더리스 컬렉션',
-            cord: 'genderless',
+            code: 'genderless',
           },
           {
             id: 20108,
             title: '1 ON 1 상품설명 서비스',
-            cord: 'one_on_one',
+            code: 'one_on_one',
           },
           {
             id: 20109,
             title: 'SALE',
-            cord: 'sale',
+            code: 'sale',
           },
         ]
       },
       {
         id: 202,
         title: '신발',
-        cord: 'shoes',
+        code: 'shoes',
         tertiary: [
           {
             id: 20201,
             title: '신발 전체',
-            cord: '',
+            code: '',
           },
           {
             id: 20202,
             title: '라이프스타일',
-            cord: 'lifestyle',
+            code: 'lifestyle',
           },
           {
             id: 20203,
             title: '러닝',
-            cord: '',
+            code: 'running',
           },
           {
             id: 20204,
             title: '트레이닝 & 짐',
-            cord: '',
+            code: '',
           },
           {
             id: 20205,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 20206,
             title: '조던',
-            cord: '',
+            code: '',
           },
           {
             id: 20207,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 20208,
             title: '스케이트 보딩',
-            cord: '',
+            code: '',
           },
           {
             id: 20209,
             title: '골프',
-            cord: '',
+            code: '',
           },
           {
             id: 20210,
             title: '테니스',
-            cord: '',
+            code: '',
           },
           {
             id: 20211,
             title: '샌들 & 슬리퍼',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 203,
         title: '의류',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 20301,
             title: '의류 전체',
-            cord: '',
+            code: '',
           },
           {
             id: 20302,
             title: '아우터웨어',
-            cord: '',
+            code: '',
           },
           {
             id: 20303,
             title: '후디 & 크루',
-            cord: '',
+            code: '',
           },
           {
             id: 20304,
             title: '팬츠 & 타이즈',
-            cord: '',
+            code: '',
           },
           {
             id: 20305,
             title: '탑 & 티셔츠',
-            cord: '',
+            code: '',
           },
           {
             id: 20306,
             title: '숏 팬츠',
-            cord: '',
+            code: '',
           },
           {
             id: 20307,
             title: '나이키 프로',
-            cord: '',
+            code: '',
           },
           {
             id: 20308,
             title: '양말',
-            cord: '',
+            code: '',
           },
           {
             id: 20309,
             title: '셋업',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 204,
         title: '스포츠',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 20401,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 20402,
             title: '트레이닝 & 짐',
-            cord: '',
+            code: '',
           },
           {
             id: 20403,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 20404,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 20405,
             title: '스케이트보딩',
-            cord: '',
+            code: '',
           },
           {
             id: 20406,
             title: '골프',
-            cord: '',
+            code: '',
           },
           {
             id: 20407,
             title: '테니스',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 205,
         title: '브랜드',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 20501,
             title: 'Nike Sportswear',
-            cord: '',
+            code: '',
           },
           {
             id: 20502,
             title: 'NikeLab',
-            cord: '',
+            code: '',
           },
           {
             id: 20503,
             title: 'Jordan',
-            cord: '',
+            code: '',
           },
           {
             id: 20504,
             title: 'NBA',
-            cord: '',
+            code: '',
           },
           {
             id: 20505,
             title: 'ACG',
-            cord: '',
+            code: '',
           },
         ]
       },
@@ -379,245 +379,245 @@ export const NAV_CATEGORIES = [
   {
     id: 3,
     title: 'Women',
-    cord: '',
+    code: '',
     secondary: [
       {
         id: 301,
         title: 'New & Featured',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 30101,
             title: '신상품',
-            cord: '',
+            code: '',
           },
           {
             id: 30102,
             title: 'SNKRS',
-            cord: '',
+            code: '',
           },
           {
             id: 30103,
             title: 'THE BEST',
-            cord: '',
+            code: '',
           },
           {
             id: 30104,
             title: 'MEMBER SHOP',
-            cord: '',
+            code: '',
           },
           {
             id: 30105,
             title: '윈터웨어 컬렉션',
-            cord: '',
+            code: '',
           },
           {
             id: 30106,
             title: '줌 X 인빈서블 런 플라이니트',
-            cord: '',
+            code: '',
           },
           {
             id: 30107,
             title: '젠더리스 컬렉션',
-            cord: '',
+            code: '',
           },
           {
             id: 30108,
             title: '1 ON 1 상품설명 서비스',
-            cord: '',
+            code: '',
           },
           {
             id: 30109,
             title: 'SALE',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 302,
         title: '신발',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 30201,
             title: '신발 전체',
-            cord: '',
+            code: '',
           },
           {
             id: 30202,
             title: '라이프스타일',
-            cord: '',
+            code: '',
           },
           {
             id: 30203,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 30204,
             title: '트레이닝 & 짐',
-            cord: '',
+            code: '',
           },
           {
             id: 30205,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 30206,
             title: '조던',
-            cord: '',
+            code: '',
           },
           {
             id: 30207,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 30208,
             title: '스케이트 보딩',
-            cord: '',
+            code: '',
           },
           {
             id: 30209,
             title: '골프',
-            cord: '',
+            code: '',
           },
           {
             id: 30210,
             title: '테니스',
-            cord: '',
+            code: '',
           },
           {
             id: 30211,
             title: '샌들 & 슬리퍼',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 303,
         title: '의류',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 30301,
             title: '의류 전체',
-            cord: '',
+            code: '',
           },
           {
             id: 30302,
             title: '아우터웨어',
-            cord: '',
+            code: '',
           },
           {
             id: 30303,
             title: '후디 & 크루',
-            cord: '',
+            code: '',
           },
           {
             id: 30304,
             title: '팬츠 & 타이즈',
-            cord: '',
+            code: '',
           },
           {
             id: 30305,
             title: '탑 & 티셔츠',
-            cord: '',
+            code: '',
           },
           {
             id: 30306,
             title: '숏 팬츠',
-            cord: '',
+            code: '',
           },
           {
             id: 30307,
             title: '나이키 프로',
-            cord: '',
+            code: '',
           },
           {
             id: 30308,
             title: '양말',
-            cord: '',
+            code: '',
           },
           {
             id: 30309,
             title: '셋업',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 304,
         title: '스포츠',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 30401,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 30402,
             title: '트레이닝 & 짐',
-            cord: '',
+            code: '',
           },
           {
             id: 30403,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 30404,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 30405,
             title: '스케이트보딩',
-            cord: '',
+            code: '',
           },
           {
             id: 30406,
             title: '골프',
-            cord: '',
+            code: '',
           },
           {
             id: 30407,
             title: '테니스',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 305,
         title: '브랜드',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 30501,
             title: 'Nike Sportswear',
-            cord: '',
+            code: '',
           },
           {
             id: 30502,
             title: 'NikeLab',
-            cord: '',
+            code: '',
           },
           {
             id: 30503,
             title: 'Jordan',
-            cord: '',
+            code: '',
           },
           {
             id: 30504,
             title: 'NBA',
-            cord: '',
+            code: '',
           },
           {
             id: 30505,
             title: 'ACG',
-            cord: '',
+            code: '',
           },
         ]
       },
@@ -626,178 +626,178 @@ export const NAV_CATEGORIES = [
   {
     id: 4,
     title: 'Kids',
-    cord: '',
+    code: '',
     secondary: [
       {
         id: 401,
         title: 'New & Featured',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 40101,
             title: '신상품',
-            cord: '',
+            code: '',
           },
           {
             id: 40102,
             title: 'GOOD PRICE 컬렉션',
-            cord: '',
+            code: '',
           },
           {
             id: 40103,
             title: '키즈 윈터웨어 컬렉션',
-            cord: '',
+            code: '',
           },
           {
             id: 40104,
             title: '나이키 키즈 클래식',
-            cord: '',
+            code: '',
           },
           {
             id: 40105,
             title: '조던 키즈',
-            cord: '',
+            code: '',
           },
           {
             id: 40106,
             title: '아이들을 위한 선물',
-            cord: '',
+            code: '',
           },
           {
             id: 40107,
             title: 'SALE',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 402,
         title: '신발',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 40201,
             title: '베이비(160mm 이하)',
-            cord: '',
+            code: '',
           },
           {
             id: 40202,
             title: '리틀키즈(160-220mm)',
-            cord: '',
+            code: '',
           },
           {
             id: 40203,
             title: '주니어(225-250mm)',
-            cord: '',
+            code: '',
           },
           {
             id: 40204,
             title: '라이프스타일',
-            cord: '',
+            code: '',
           },
           {
             id: 40205,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 40206,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 40207,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 40208,
             title: '샌들 & 슬리퍼',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 403,
         title: '의류',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 40301,
             title: '베이비(0-4세)',
-            cord: '',
+            code: '',
           },
           {
             id: 40302,
             title: '리틀키즈(4-7세)',
-            cord: '',
+            code: '',
           },
           {
             id: 40303,
             title: '주니어(8-13세)',
-            cord: '',
+            code: '',
           },
           {
             id: 40304,
             title: '아우터웨어',
-            cord: '',
+            code: '',
           },
           {
             id: 40305,
             title: '후디 & 크루',
-            cord: '',
+            code: '',
           },
           {
             id: 40306,
             title: '팬츠 & 레깅스',
-            cord: '',
+            code: '',
           },
           {
             id: 40307,
             title: '트랙수트 & 세트',
-            cord: '',
+            code: '',
           },
           {
             id: 40308,
             title: '탑 & 티셔츠',
-            cord: '',
+            code: '',
           },
           {
             id: 40309,
             title: '스커트 & 드레스',
-            cord: '',
+            code: '',
           },
           {
             id: 40310,
             title: '가방 & 모자 & 용품',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 404,
         title: '스포츠',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 40401,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 40402,
             title: '농구',
-            cord: '',
+            code: '',
           },
           {
             id: 40403,
             title: '축구',
-            cord: '',
+            code: '',
           },
           {
             id: 40404,
             title: '테니스',
-            cord: '',
+            code: '',
           },
         ]
       },
@@ -806,103 +806,103 @@ export const NAV_CATEGORIES = [
   {
     id: 5,
     title: 'Sale',
-    cord: '',
+    code: '',
     secondary: [
       {
         id: 501,
         title: 'New To Sale',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 50101,
             title: 'SALE: 아우터웨어',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 502,
         title: 'Mens Sale',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 50201,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 50202,
             title: '라이프스타일',
-            cord: '',
+            code: '',
           },
           {
             id: 50203,
             title: '트레이닝',
-            cord: '',
+            code: '',
           },
           {
             id: 50204,
             title: '농구 & 조던',
-            cord: '',
+            code: '',
           },
           {
             id: 50205,
             title: '골프 & 테니스',
-            cord: '',
+            code: '',
           },
           {
             id: 50206,
             title: '축구',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 503,
         title: 'Womens Sale',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 50301,
             title: '러닝',
-            cord: '',
+            code: '',
           },
           {
             id: 50302,
             title: '라이프스타일',
-            cord: '',
+            code: '',
           },
           {
             id: 50303,
             title: '트레이닝',
-            cord: '',
+            code: '',
           },
           {
             id: 50304,
             title: '골프 & 테니스',
-            cord: '',
+            code: '',
           },
         ]
       },
       {
         id: 504,
         title: 'Kids Sale',
-        cord: '',
+        code: '',
         tertiary: [
           {
             id: 50401,
             title: '베이비(0-4세)',
-            cord: '',
+            code: '',
           },
           {
             id: 50402,
             title: '리틀키즈(4-7세)',
-            cord: '',
+            code: '',
           },
           {
             id: 50403,
             title: '주니어(8-13세)',
-            cord: '',
+            code: '',
           },
         ]
       },
@@ -914,21 +914,21 @@ export const SEARCH_KEYWORD = [
   {
     id: 0,
     keyword: '에어모지',
-    cord: '',
+    code: '',
   },
   {
     id: 1,
     keyword: 'ACG',
-    cord: '',
+    code: '',
   },
   {
     id: 2,
     keyword: '나이키 뮬',
-    cord: '',
+    code: '',
   },
   {
     id: 3,
     keyword: '윈터 아이템',
-    cord: '',
+    code: '',
   },
 ]

--- a/client/src/Components/Header/Login/LoginAccess/LoginAccessTitle.jsx
+++ b/client/src/Components/Header/Login/LoginAccess/LoginAccessTitle.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 const LoginAccessTitle = () => {
   return (
     <AccessTitle>
-      <img src="./Images/logo-nike.png" alt="logo-nike" />
+      <img src="/Images/logo-nike.png" alt="logo-nike" />
       <h2>나이켈 로그인</h2>
     </AccessTitle>
   )

--- a/client/src/Components/Header/components/HeaderNavbar.jsx
+++ b/client/src/Components/Header/components/HeaderNavbar.jsx
@@ -32,7 +32,7 @@ const HeaderNavbar = () => {
     <Headernavbar isFixed={window.pageYOffset > 36} isHide={navHide}>
       <NavWrapper>
         <NavLogo to="/">
-          <img src="./Images/logo-nike.png" alt="logo-nike" onMouseEnter={exitCategories}/>
+          <img src="/Images/logo-nike.png" alt="logo-nike" onMouseEnter={exitCategories}/>
         </NavLogo>
         <NavMenu navFocus={navFocus} setNavFocus={setNavFocus} />
         <NavTools setSearchOn={setSearchOn} exitCategories={exitCategories} />

--- a/client/src/Components/Header/components/HeaderUserMenu.jsx
+++ b/client/src/Components/Header/components/HeaderUserMenu.jsx
@@ -31,7 +31,7 @@ const HeaderUserMenu = ({ setIsLoginOn }) => {
   return (
     <Headerusermenu>
       <Linker to="/">
-        <img src="./Images/logo-jumpman.png" alt="logo-jumpman" />
+        <img src="/Images/logo-jumpman.png" alt="logo-jumpman" />
       </Linker>
       <ul className="client-menu">
         <li><Linker to="/client">고객센터</Linker></li>

--- a/client/src/Components/Header/components/Navbar/NavCategories.jsx
+++ b/client/src/Components/Header/components/Navbar/NavCategories.jsx
@@ -1,24 +1,41 @@
 import React from 'react'
 import styled, { css, keyframes } from 'styled-components';
-import { Linker } from '../../../../Common/StyledCommon';
+import { Link } from 'react-router-dom';
 import { flexAlignStart } from '../../../../Styles/theme';
 import { NAV_CATEGORIES } from '../../HeaderData';
 
 const NavCategories = ({ isShown, navFocus, setNavFocus }) => {
+  const setCategory = (navFocus) => {
+    const { cord, secondary } = NAV_CATEGORIES.find(category => category.id === navFocus);
+    return (
+      <>
+        {secondary.map(second => 
+          <ul key={second.id}>
+            <Link to={`/list/${cord}/${second.cord}`}><h4>{second.title}</h4></Link>
+            {second.tertiary.map(third => 
+              <Link to={`/list/${cord}/${second.cord}/${third.cord}`}><li key={third.id}>{third.title}</li></Link>
+            )}
+          </ul>
+        )}
+      </>
+    )
+  }
   return (
     <Navcategories isShown={isShown}>
       <CategoryFilter isShown={isShown} onMouseEnter={() => setNavFocus(0)} />
       <CategoryMenu className={isShown ? 'show' : ''}>
-        {navFocus > 0 && NAV_CATEGORIES.find(category => category.id === navFocus).secondary.map(sub => {
-          return (
-            <ul key={sub.id}>
-              <Linker to={sub.link}><h4>{sub.title}</h4></Linker>
-              {sub.tertiary.map(content => 
-                <Linker to={content.link}><li key={content.id}>{content.title}</li></Linker>
-              )}
-            </ul>
-          )  
-          })}
+        {navFocus > 0 && setCategory(navFocus)
+          // NAV_CATEGORIES.find(category => category.id === navFocus).secondary.map(ele => {
+          //   return (
+          //     <ul key={ele.id}>
+          //       <Link to={`/${ele.cord}`}><h4>{ele.title}</h4></Link>
+          //       {ele.tertiary.map(sub_ele => 
+          //         <Link to={`/${ele.cord}/${sub_ele.cord}`}><li key={sub_ele.id}>{sub_ele.title}</li></Link>
+          //       )}
+          //     </ul>
+          //   )  
+          // })
+        }
       </CategoryMenu>
     </Navcategories>
   )

--- a/client/src/Components/Header/components/Navbar/NavCategories.jsx
+++ b/client/src/Components/Header/components/Navbar/NavCategories.jsx
@@ -6,14 +6,14 @@ import { NAV_CATEGORIES } from '../../HeaderData';
 
 const NavCategories = ({ isShown, navFocus, setNavFocus }) => {
   const setCategory = (navFocus) => {
-    const { cord, secondary } = NAV_CATEGORIES.find(category => category.id === navFocus);
+    const { code, secondary } = NAV_CATEGORIES.find(category => category.id === navFocus);
     return (
       <>
         {secondary.map(second => 
           <ul key={second.id}>
-            <Link to={`/list/${cord}/${second.cord}`}><h4>{second.title}</h4></Link>
+            <a href={`/list/${code}/${second.code}`}><h4>{second.title}</h4></a>
             {second.tertiary.map(third => 
-              <Link to={`/list/${cord}/${second.cord}/${third.cord}`}><li key={third.id}>{third.title}</li></Link>
+              <a href={`/list/${code}/${second.code}/${third.code}`}><li key={third.id}>{third.title}</li></a>
             )}
           </ul>
         )}
@@ -24,18 +24,7 @@ const NavCategories = ({ isShown, navFocus, setNavFocus }) => {
     <Navcategories isShown={isShown}>
       <CategoryFilter isShown={isShown} onMouseEnter={() => setNavFocus(0)} />
       <CategoryMenu className={isShown ? 'show' : ''}>
-        {navFocus > 0 && setCategory(navFocus)
-          // NAV_CATEGORIES.find(category => category.id === navFocus).secondary.map(ele => {
-          //   return (
-          //     <ul key={ele.id}>
-          //       <Link to={`/${ele.cord}`}><h4>{ele.title}</h4></Link>
-          //       {ele.tertiary.map(sub_ele => 
-          //         <Link to={`/${ele.cord}/${sub_ele.cord}`}><li key={sub_ele.id}>{sub_ele.title}</li></Link>
-          //       )}
-          //     </ul>
-          //   )  
-          // })
-        }
+        {navFocus > 0 && setCategory(navFocus)}
       </CategoryMenu>
     </Navcategories>
   )

--- a/client/src/Components/Header/components/Navbar/NavLogo.jsx
+++ b/client/src/Components/Header/components/Navbar/NavLogo.jsx
@@ -6,7 +6,7 @@ import { flexAlign } from '../../../../Styles/theme';
 const NavLogo = () => {
   return (
     <Navlogo to="/">
-      <img src="./Images/logo-nike.png" alt="logo-nike" />
+      <img src="/Images/logo-nike.png" alt="logo-nike" />
     </Navlogo>
   )
 }

--- a/client/src/Containers/List/List.jsx
+++ b/client/src/Containers/List/List.jsx
@@ -5,33 +5,35 @@ import ListHeader from './components/ListHeader';
 import ListFilter from './components/ListFilter/ListFilter';
 import ListItemWrapper from './components/ListItemWrapper/ListItemWrapper';
 import { loadItemList } from '../../Store/Action/itemListAction';
-import { ITEMS_API } from '../../Data/config';
 import { flexAlignStart } from '../../Styles/theme';
-import itemsList_MOCK from '../../Data/data';
 
 const List = () => {
   const [filterOn, setFilterOn] = useState(true);
   const [sortMode, setSortMode] = useState('new');
   const [isFixed, setIsFixed] = useState(false);
-  const [itemList, setItemList] = useState(itemsList_MOCK);
+  const [itemList, setItemList] = useState([]);
 
+  const itemListState = useSelector(state => state.itemList);
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadItemList(window.location.pathname.slice(5), {}))
+  }, [dispatch])
+
+  useEffect(() => {
+    setItemList(itemListState.list);
+  }, [itemListState])
 
   const handleScroll = useCallback(() => {
     const { pageYOffset } = window;
     setIsFixed(pageYOffset > 37)
 
-    const scrollHeight = document.documentElement.scrollHeight;
-    const scrollTop = document.documentElement.scrollTop;
-    const clientHeight = document.documentElement.clientHeight;
-    if (scrollTop + clientHeight >= scrollHeight) {
-      setItemList(itemList.concat(itemsList_MOCK))
+    const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
+    if (scrollTop + clientHeight >= scrollHeight && itemList.length > 5) {
+      dispatch(loadItemList(window.location.pathname.slice(5), {}))
+      window.scrollTo(0, scrollTop-1)
     }
-  }, [itemList])
-
-  useEffect(() => {
-    dispatch(loadItemList(window.location.pathname.slice(5), {}))
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);
@@ -56,7 +58,9 @@ const ListPage = styled.div`
 const ListMain = styled.div`
   position: absolute;
   top: 110px;
-  ${flexAlignStart}
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
   width: 100%;
   padding: 0 48px 20px 0;
 `;

--- a/client/src/Containers/List/List.jsx
+++ b/client/src/Containers/List/List.jsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
-import { flexAlignStart } from '../../Styles/theme';
+import { useSelector, useDispatch } from 'react-redux';
 import ListHeader from './components/ListHeader';
 import ListFilter from './components/ListFilter/ListFilter';
 import ListItemWrapper from './components/ListItemWrapper/ListItemWrapper';
+import { loadItemList } from '../../Store/Action/itemListAction';
+import { ITEMS_API } from '../../Data/config';
+import { flexAlignStart } from '../../Styles/theme';
 import itemsList_MOCK from '../../Data/data';
 
 const List = () => {
@@ -11,6 +14,8 @@ const List = () => {
   const [sortMode, setSortMode] = useState('new');
   const [isFixed, setIsFixed] = useState(false);
   const [itemList, setItemList] = useState(itemsList_MOCK);
+
+  const dispatch = useDispatch();
 
   const handleScroll = useCallback(() => {
     const { pageYOffset } = window;
@@ -23,6 +28,10 @@ const List = () => {
       setItemList(itemList.concat(itemsList_MOCK))
     }
   }, [itemList])
+
+  useEffect(() => {
+    dispatch(loadItemList(window.location.pathname.slice(5), {}))
+  }, [])
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);

--- a/client/src/Containers/List/List.jsx
+++ b/client/src/Containers/List/List.jsx
@@ -5,7 +5,6 @@ import ListHeader from './components/ListHeader';
 import ListFilter from './components/ListFilter/ListFilter';
 import ListItemWrapper from './components/ListItemWrapper/ListItemWrapper';
 import { loadItemList } from '../../Store/Action/itemListAction';
-import { flexAlignStart } from '../../Styles/theme';
 
 const List = () => {
   const [filterOn, setFilterOn] = useState(true);
@@ -29,7 +28,7 @@ const List = () => {
     setIsFixed(pageYOffset > 37)
 
     const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
-    if (scrollTop + clientHeight >= scrollHeight && itemList.length > 5) {
+    if (scrollTop + clientHeight >= scrollHeight) {
       dispatch(loadItemList(window.location.pathname.slice(5), {}))
       window.scrollTo(0, scrollTop-1)
     }

--- a/client/src/Containers/List/components/ListFilter/FilterBox.jsx
+++ b/client/src/Containers/List/components/ListFilter/FilterBox.jsx
@@ -20,7 +20,9 @@ const FilterBox = ({ children, title, gridCol, gridGap }) => {
 
 const Filterbox = styled.section`
   padding: 20px 0;
+  background: #ffffff;
   border-top: 1px solid ${({ theme }) => theme.gray1};
+  z-index: 10;
 `;
 
 const FilterBoxTitle = styled.div`
@@ -41,14 +43,16 @@ const FilterBoxCategories = styled.ul`
   grid-template-columns: ${({ gridCol }) => gridCol || '1fr'};
   grid-gap: ${({ gridGap }) => gridGap || '0'};
   transition: ${({ theme }) => theme.transition};
+  overflow: hidden;
   ${({ isFold }) => !isFold
     ? css`
+      height: 100%;
       visibility: visible;
       opacity: 1;
       margin: 20px 0 10px;
     `
     : css`
-      height: 0px;
+      height: 0;
       visibility: hidden;
       opacity: 0;
     `

--- a/client/src/Containers/List/components/ListFilter/ListFilter.jsx
+++ b/client/src/Containers/List/components/ListFilter/ListFilter.jsx
@@ -95,7 +95,7 @@ const Listfilter = styled.aside`
 `;
 
 const FilterContainer = styled.div`
-  width: 200px;
+  width: 204px;
   height: 100%;
 `;
 

--- a/client/src/Containers/List/components/ListFilter/ListFilter.jsx
+++ b/client/src/Containers/List/components/ListFilter/ListFilter.jsx
@@ -67,6 +67,7 @@ const ListFilter = ({ isFixed, filterOn }) => {
 const Listfilter = styled.aside`
   padding: 0 48px;
   transition: ${({ theme }) => theme.transition};
+  z-index: 10;
   ${({ filterOn }) => filterOn
     ? css`
       visibility: visible;

--- a/client/src/Containers/List/components/ListHeader.jsx
+++ b/client/src/Containers/List/components/ListHeader.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled, { css } from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { sortItemList } from '../../../Store/Action/itemListAction';
 import { Button } from '../../../Common/StyledCommon';
 import { flexCenter, flexBetween } from '../../../Styles/theme';
 import { FaList } from 'react-icons/fa';
@@ -9,6 +11,8 @@ const ListHeader = ({ isFixed, filterOn, setFilterOn, sortMode, setSortMode }) =
   const [pageY, setPageY] = useState(0);
   const [headerUp, setHeaderUp] = useState(false);
   const [sortOn, setSortOn] = useState(false);
+  const dispatch = useDispatch();
+
   const sortModeList = {
     'new': '신상품순',
     'expensive': '높은 가격순',
@@ -25,6 +29,12 @@ const ListHeader = ({ isFixed, filterOn, setFilterOn, sortMode, setSortMode }) =
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, [handleScroll])
+
+  const changeSortMode = (mode) => {
+    setSortMode(mode)
+    setSortOn(false);
+    dispatch(sortItemList(mode))
+  }
 
   return (
     <Listheader isFixed={isFixed} isUp={headerUp} >
@@ -43,7 +53,9 @@ const ListHeader = ({ isFixed, filterOn, setFilterOn, sortMode, setSortMode }) =
         </Button>
         {sortOn && <SortModal>
           {Object.entries(sortModeList).map((mode) => 
-            <li onClick={() => setSortMode(mode[0])}><span>{mode[1]}</span></li>
+            <li onClick={() => changeSortMode(mode[0])}>
+              <span>{mode[1]}</span>
+            </li>
           )}
         </SortModal>}
       </aside>

--- a/client/src/Containers/List/components/ListItemWrapper/ListItem.jsx
+++ b/client/src/Containers/List/components/ListItemWrapper/ListItem.jsx
@@ -71,6 +71,8 @@ const Listitem = styled(Link)`
 
   img {
     width: 100%;
+    height: 400px;
+    object-fit: cover;
   }
 
   &:hover {
@@ -98,7 +100,7 @@ const ItemInfoMain = styled.div`
 const ItemInfoSub = styled.p`
   position: relative;
   margin: 10px 0 0;
-  color: ${({ theme }) => theme.gray2};
+  color: ${({ theme }) => theme.gray1};
 `;
 
 

--- a/client/src/Containers/List/components/ListItemWrapper/ListItem.jsx
+++ b/client/src/Containers/List/components/ListItemWrapper/ListItem.jsx
@@ -5,13 +5,13 @@ import { Link } from 'react-router-dom';
 const ListItem = ({ itemInfo }) => {
   const { id, images, name, category, sizes, colors, price } = itemInfo;
   const { primary, secondary, tertiary } = category;
-  const { cord, otherColors } = colors;
+  const { code, otherColors } = colors;
 
   const [image, setImage] = useState('');
 
   return (
     <Listitem to={`/details/${id}`} >
-      <img src={image || images[0]} alt={`${primary.title}-${name}-${cord}`} />
+      <img src={image || images[0]} alt={`${primary.title}-${name}-${code}`} />
       <ListItemInfo>
         <ItemInfoMain>
           <div>
@@ -32,14 +32,13 @@ const ListItem = ({ itemInfo }) => {
                   onMouseOver={() => setImage(color.image)}
                   onMouseOut={() => setImage('')}
                 >
-                  <img src={color.image} alt={`${primary.title}-${name}-${color.cord}`} />
+                  <img src={color.image} alt={`${primary.title}-${name}-${color.code}`} />
                 </Link>
               )
             })}
           </ItemInfoColors>
         </ItemInfoSub>
       </ListItemInfo>
-
     </Listitem>
   )
 }
@@ -67,7 +66,8 @@ const ItemInfoColors = styled.div`
 `;
 
 const Listitem = styled(Link)`
-  margin: 0 0 50px;
+  padding: 0 0 20px;
+  margin: 0 0 20px;
 
   img {
     width: 100%;

--- a/client/src/Containers/List/components/ListItemWrapper/ListItemWrapper.jsx
+++ b/client/src/Containers/List/components/ListItemWrapper/ListItemWrapper.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import ListItem from './ListItem';
-import itemsList_MOCK from '../../../../Data/data';
 
 const ListItemWrapper = ({ itemList, isFixed, filterOn }) => {
   return (
@@ -15,14 +14,23 @@ const ListItemWrapper = ({ itemList, isFixed, filterOn }) => {
 
 const ItemWrapper = styled.main`
   position: relative;
+  width: 100%;
+
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 20px;
-  transition: ${({ theme }) => theme.transition};
+  margin: 0 0 50px 0;
+  /* transition: ${({ theme }) => theme.transition}; */
   padding-left: ${({ isFixed, filterOn }) => filterOn
     ? isFixed ? '300px' : '0px'
     : '48px'
   };
 `;
+
+// const toWide = keyframes`
+//   from {
+//     padding-left:
+//   }
+// `;
 
 export default ListItemWrapper

--- a/client/src/Containers/Main/Main.jsx
+++ b/client/src/Containers/Main/Main.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexCenter } from '../../Styles/theme';
+
+const Main = () => {
+  return (
+    <MainPage>
+      <h1>here is main!</h1>
+    </MainPage>
+  )
+}
+
+const MainPage = styled.div`
+  ${flexCenter};
+  height: 100vh;
+`;
+
+export default Main

--- a/client/src/Containers/Register/components/RegisterForm/FormCheckWrapper.jsx
+++ b/client/src/Containers/Register/components/RegisterForm/FormCheckWrapper.jsx
@@ -25,7 +25,7 @@ const FormCheckWrapper = ({ isChecked, setIsChecked }) => {
       </FormCheckClause>
       <FormCheckInfo>
         <h6>개인정보 수집, 이용 동의</h6>
-        <img src="./Images/info1.png" alt="check-info-alternative-img" />
+        <img src="/Images/info1.png" alt="check-info-alternative-img" />
         <CheckCon>
           <input type="checkbox" name="privacy" onClick={(e) => updateCheck(e)} />
           <p>[필수] 개인정보 수집, 이용에 동의 합니다.</p>
@@ -35,7 +35,7 @@ const FormCheckWrapper = ({ isChecked, setIsChecked }) => {
       </FormCheckInfo>
       <FormCheckPromote>
         <h6>선택적 개인정보 수집, 이용 동의</h6>
-        <img src="./Images/info2.png" alt="check-info-alternative-img2" />
+        <img src="/Images/info2.png" alt="check-info-alternative-img2" />
         <CheckCon>
           <input type="checkbox" name="privacyMore" onClick={(e) => updateCheck(e)} />
           <p>[선택] 개인정보 수집, 이용에 동의 합니다.</p>

--- a/client/src/Data/data.js
+++ b/client/src/Data/data.js
@@ -2,12 +2,12 @@ const itemsList_MOCK = [
   {
     id: 10001010,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -43,17 +43,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default2.jpeg',
+          image: '/Images/default2.jpeg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default2.jpeg',
+          image: '/Images/default2.jpeg',
           cord: 'navy',
         },
       ]
@@ -67,12 +67,12 @@ const itemsList_MOCK = [
   {
     id: 10001001,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -108,17 +108,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -132,12 +132,12 @@ const itemsList_MOCK = [
   {
     id: 10001002,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -173,17 +173,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -197,12 +197,12 @@ const itemsList_MOCK = [
   {
     id: 10001003,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -238,17 +238,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -262,12 +262,12 @@ const itemsList_MOCK = [
   {
     id: 10001004,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -303,17 +303,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -327,12 +327,12 @@ const itemsList_MOCK = [
   {
     id: 10001005,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -368,17 +368,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -392,12 +392,12 @@ const itemsList_MOCK = [
   {
     id: 10001006,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -433,17 +433,17 @@ const itemsList_MOCK = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]

--- a/client/src/Data/data.js
+++ b/client/src/Data/data.js
@@ -12,15 +12,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -38,23 +38,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default2.jpeg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default2.jpeg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -77,15 +77,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -103,23 +103,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -142,15 +142,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -168,23 +168,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -207,15 +207,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -233,23 +233,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -272,15 +272,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -298,23 +298,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -337,15 +337,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -363,23 +363,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -402,15 +402,15 @@ const itemsList_MOCK = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -428,23 +428,23 @@ const itemsList_MOCK = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },

--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import GlobalReset from './Styles/reset';
 import theme from './Styles/theme';
 import Header from './Components/Header/Header';
+import Main from './Containers/Main/Main';
 import List from './Containers/List/List';
 import Register from './Containers/Register/Register';
 
@@ -14,7 +15,8 @@ function Routes() {
       <GlobalReset />
         <Header />
         <Switch>
-          <Route exact path="/" component={List} />
+          <Route exact path="/" component={Main} />
+          <Route path="/list" component={List} />
           <Route exact path="/register" component={Register} />
         </Switch>
         {/* <Footer /> */}

--- a/client/src/Store/Action/itemListAction.js
+++ b/client/src/Store/Action/itemListAction.js
@@ -3,10 +3,11 @@ export const LOAD_ITEMLIST_SUCCESS = 'LOAD_ITEMLIST_SUCCESS';
 export const LOAD_ITEMLIST_FAILURE = 'LOAD_ITEMLIST_FAILURE';
 export const SORT_ITEMLIST = 'SORT_ITEMLIST';
 
-export const loadItemList = (query) => {
+export const loadItemList = (path, query) => {
   return {
     type: LOAD_ITEMLIST,
-    query
+    path,
+    query,
   }
 }
 

--- a/client/src/Store/Action/itemListAction.js
+++ b/client/src/Store/Action/itemListAction.js
@@ -11,10 +11,10 @@ export const loadItemList = (path, query) => {
   }
 }
 
-export const loadItemSuccess = (data) => {
+export const loadItemSuccess = (list) => {
   return {
     type: LOAD_ITEMLIST_SUCCESS,
-    data,
+    list,
   }
 }
 

--- a/client/src/Store/Action/itemListAction.js
+++ b/client/src/Store/Action/itemListAction.js
@@ -3,11 +3,10 @@ export const LOAD_ITEMLIST_SUCCESS = 'LOAD_ITEMLIST_SUCCESS';
 export const LOAD_ITEMLIST_FAILURE = 'LOAD_ITEMLIST_FAILURE';
 export const SORT_ITEMLIST = 'SORT_ITEMLIST';
 
-export const loadItemList = (path, query) => {
+export const loadItemList = (path) => {
   return {
     type: LOAD_ITEMLIST,
     path,
-    query,
   }
 }
 

--- a/client/src/Store/Reducer/itemListReducer.js
+++ b/client/src/Store/Reducer/itemListReducer.js
@@ -17,6 +17,7 @@ const initialItemList = {
       code: '',
     },
   },
+  path: '',
   filter: {},
   sortMode: 'new',
 }
@@ -26,6 +27,7 @@ const itemListReducer = (state = initialItemList, action) => {
     case LOAD_ITEMLIST:
       return {
         ...state,
+        path: action.path,
         query: state.filter,
       }
 

--- a/client/src/Store/Reducer/itemListReducer.js
+++ b/client/src/Store/Reducer/itemListReducer.js
@@ -1,5 +1,7 @@
 import { LOAD_ITEMLIST, LOAD_ITEMLIST_SUCCESS, LOAD_ITEMLIST_FAILURE, SORT_ITEMLIST } from '../Action/itemListAction';
 
+const LIMIT = 10;
+
 const initialItemList = {
   list: [],
   round: 0,
@@ -14,14 +16,17 @@ const itemListReducer = (state = initialItemList, action) => {
       return {
         ...state,
         path: action.path,
+        round: state.round,
         query: state.filter,
       }
 
     case LOAD_ITEMLIST_SUCCESS:
-      const concatList = state.list.concat(action.newList)
+      const offset = state.round * LIMIT;
+      const concatList = state.list.concat(action.newList.slice(offset, offset+LIMIT));
       return {
         ...state,
         list: concatList.reduce((acc, cur) => acc.includes(cur) ? acc : [...acc, cur], []),
+        round: state.round + 1,
       }
     
     case LOAD_ITEMLIST_FAILURE:

--- a/client/src/Store/Reducer/itemListReducer.js
+++ b/client/src/Store/Reducer/itemListReducer.js
@@ -1,22 +1,8 @@
 import { LOAD_ITEMLIST, LOAD_ITEMLIST_SUCCESS, LOAD_ITEMLIST_FAILURE, SORT_ITEMLIST } from '../Action/itemListAction';
 
 const initialItemList = {
-  itemList: [],
+  list: [],
   round: 0,
-  category: {
-    primary: {
-      id: 0,
-      code: '',
-    },
-    secondary: {
-      id: 0,
-      code: '',
-    },
-    tertiary: {
-      id: 0,
-      code: '',
-    },
-  },
   path: '',
   filter: {},
   sortMode: 'new',
@@ -32,9 +18,10 @@ const itemListReducer = (state = initialItemList, action) => {
       }
 
     case LOAD_ITEMLIST_SUCCESS:
+      const concatList = state.list.concat(action.newList)
       return {
         ...state,
-        itemList: action.data,
+        list: concatList.reduce((acc, cur) => acc.includes(cur) ? acc : [...acc, cur], []),
       }
     
     case LOAD_ITEMLIST_FAILURE:
@@ -44,19 +31,21 @@ const itemListReducer = (state = initialItemList, action) => {
       }
 
     case SORT_ITEMLIST:
-      let newItemList = state.itemList;
+      let newItemList = state.list;
       if (action.mode === 'new') {
-        newItemList.sort((a,b) => a.date.launched > b.date.launched ? a : b);
+        newItemList = newItemList.sort((a,b) => a.date.launched - b.date.launched);
       }
       else if (action.mode === 'expensive') {
-        newItemList.sort((a,b) => a.price > b.price ? a : b);
+        newItemList = newItemList.sort((a,b) => b.price - a.price);
       }
       else if (action.mode === 'cheap') {
-        newItemList.sort((a,b) => a.price > b.price ? b : a);
+        newItemList = newItemList.sort((a,b) => a.price - b.price);
       }
+
       return {
         ...state,
-        itemList: newItemList,
+        list: newItemList,
+        sortMode: action.mode,
       }
 
     default:

--- a/client/src/Store/Saga/itemListSaga.js
+++ b/client/src/Store/Saga/itemListSaga.js
@@ -3,19 +3,16 @@ import axios from 'axios';
 import { LOAD_ITEMLIST, LOAD_ITEMLIST_SUCCESS, LOAD_ITEMLIST_FAILURE } from '../Action/itemListAction';
 import { ITEMS_API } from '../../Data/config';
 
-// function itemListApi(path) {
-//   return axios.get(ITEMS_API);
-// }
+function itemListApi(path) {
+  return axios.get(`${ITEMS_API}${path}`);
+}
 
 function* fetchItemList(action) {
   try {
-    const data = yield call(() => {
-      axios.get(`${ITEMS_API}${action.path}`)
-    });
-    yield console.log(data);
+    const result = yield call(itemListApi, action.path);
     yield put({
       type: LOAD_ITEMLIST_SUCCESS,
-      itemList: data,
+      newList: result.data.itemList,
     })
   }
   catch(error) {

--- a/client/src/Store/Saga/itemListSaga.js
+++ b/client/src/Store/Saga/itemListSaga.js
@@ -3,17 +3,19 @@ import axios from 'axios';
 import { LOAD_ITEMLIST, LOAD_ITEMLIST_SUCCESS, LOAD_ITEMLIST_FAILURE } from '../Action/itemListAction';
 import { ITEMS_API } from '../../Data/config';
 
-function itemListApi() {
-  return axios.get(ITEMS_API);
-}
+// function itemListApi(path) {
+//   return axios.get(ITEMS_API);
+// }
 
 function* fetchItemList(action) {
   try {
-    const data = yield call(itemListApi, action.query);
-    console.log(data);
+    const data = yield call(() => {
+      axios.get(`${ITEMS_API}${action.path}`)
+    });
+    yield console.log(data);
     yield put({
       type: LOAD_ITEMLIST_SUCCESS,
-      data: action.data,
+      itemList: data,
     })
   }
   catch(error) {

--- a/client/src/Store/Saga/itemListSaga.js
+++ b/client/src/Store/Saga/itemListSaga.js
@@ -9,7 +9,7 @@ function itemListApi(path) {
 
 function* fetchItemList(action) {
   try {
-    const result = yield call(itemListApi, action.path);
+    const result = yield call(itemListApi, action.path, action.round);
     yield put({
       type: LOAD_ITEMLIST_SUCCESS,
       newList: result.data.itemList,

--- a/server/database/itemsData.js
+++ b/server/database/itemsData.js
@@ -1,667 +1,830 @@
-let itemsData = [
-  {
-    id: 10001010,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'running',
-        title: '러닝',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default2.jpeg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default2.jpeg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 129000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001001,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 0,
-      235: 0,
-      240: 0,
-      245: 0,
-      250: 0,
-      255: 0,
-      260: 0,
-      265: 0,
-      270: 0,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001002,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001003,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'running',
-        title: '러닝',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001004,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001005,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001006,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001009,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001020,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
-  {
-    id: 10001024,
-    images: [
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-      '/Images/default.jpg',
-    ],
-    name: '나이키 에어맥스 테일 윈드 5SP',
-    category: {
-      primary: {
-        code: 'male',
-        title: '남성',
-      },
-      secondary: {
-        code: 'shoes',
-        title: '신발',
-      },
-      tertiary: {
-        code: 'lifestyle',
-        title: '라이프스타일',
-      }
-    },
-    sizes: {
-      230: 10,
-      235: 10,
-      240: 10,
-      245: 10,
-      250: 0,
-      255: 10,
-      260: 10,
-      265: 0,
-      270: 10,
-      275: 0,
-      280: 0,
-    },
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default.jpg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default.jpg',
-          code: 'navy',
-        },
-      ]
-    },
-    price: 209000,
-    date: {
-      launched: 1615200000000,
-      updated: 1617200000000,
-    },
-  },
+let itemsData = [];
+
+const randomer = (src) => {
+  if (typeof(src) === 'object') {
+    return src[Math.floor(Math.random() * src.length)]
+  }
+  else {
+    return Math.floor(Math.random() * src) + 1;
+  }
+}
+
+const imageArr = [
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ0pYouXNFBCF_p_pdvDClhNQFffyakJKBKKg&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ4Y0oVqzYRA2vzQK4Mj6LeK7MidJWQ-aAmVh4AkcEinM5396sXCIx73dCFIYtKzNe5AYdODdfs&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ5ymDkbGl6SH19TWVTKWxWjy5Ywbwc0pWYY17ztFRgDs4zr13gdYk6aqhBlMne9tGSVXvj9fIW&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ6kzXGVgIv32_9NUqHFwLDon4s0okB8LVUX2XcKap0FTQ20INCrQkuN2o337BkmKoHLvtrTXzg&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ70DAJQnvZ8ItTaTXvZm-2nGIFlgzLyf1Low&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ7QnhhjVTx78fA0PWdVUJxq6762XugPHy5Hw&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQBN6pRlyaW0ONLm6bch_vFUaQVy_kSzuieAA&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQFXcs30RG-HUGnzkMon71GohB68A6hoFp2nkHEWzqiZqRws40iEIiwF_EKhOKA_-0Qca4Oql0&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQUZom_u_vs1y6oX2-N1YLfOuT7NVy67lO4zg&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQdy7mlIJmAZont9upD2oNYDS00RqU5APVGiuFyEWeFY0ZhOM3xQmmBTeP6ZPBYO3Lraefk03ff&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRz-N8C_bEgp875fl4kCQo8t73qif1YzwkD1nu6Z6WgTqTCtQHeGx-CG-_ARyoNau13ngwPdMtx&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSabqzYFtr5TZTKeYwaOp8CwM_XSKzX3FqTI8iAmUzY9LpLKdrfyVIFGnzx2OFhiAn4u0DeJ8tl&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSnRteU998hZC-8Qz6Nym80k47jwTIXXmUbm7eHV7vKzhfbnRwpmt4LmnQLR6ytcTNDo33A3DQ&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSwhQmXdibA6WoxUbTG4gxyAOsLf4qNCeTxnpJuxNp5GRfzKsIuKZoB5mYQPlrFW26DS2-7K8onvw&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTZa0OHewV7CnlMZg9sE5JWpPKWaMfP_0DbzN-wo57KgdKgm6mtWEOPrd8ukRvGOncWEl4nWwtl&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqL_1e9WRIpUu4xmzC9S8IThpL8B2UYv4BVxg3eMlQ6_x90hj7cJ2_SiBtMIVs1ZPRNqd54fwoBg&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvUf5pUfaRCPRxehoJJ_3GfRBgivSGuLug1oe6EFbArkRG77HOWXRA7kkWBKz_BHqmhxDdneXM&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTyqbUvExQ4JjkpVz7b_F4_OONLlX27ea2Msw&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTzeDkmCC83isWk_9ji16wTD2WuUODM1nUJMg&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRxTlngKAliGUbhsAO1x3WIUGj0wPW8bWXiFQ&usqp=CAU',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcStKk8jBQ10P2ht2jWO2hDfBhAwLxw-n6FAVlj4EihQgbvQeW2wfGfrfZXo0NtaL_uhqQ0D-1w&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBqQauXjtXhgJBI78cgwnpsn4iyZ4X1OJFT_B4yWSj3aJvjobau6AKjLw8av6JxTln-qO44Bsw&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTZR1Im4cAzJMCZuS36VOUbqzas85193wFmpgZSbmIYjad4S4pdtNh1EpOiQ4owUACWmsZBX5xV&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTb9hJ4vGICxdLyUFvLenjLtwtlb3MWxjFzeua0LzHjhH3Jv-JPUKq3EIZse8C3LvVzhqmK4j8t&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTbhvm-7jA_hJAfVXWey6BWKvpB-ehdxjM5pYeNzF8G_tn5eAsz47ZSckHtRupKH4fTy79Me1g&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQr0LJqt5_ZKiXq1cqhnxsdT9hHbVN89nGJaRqhb76CLjhe7h5PapfSvyp_pbl4j5ceShd06mU&usqp=CAc',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQP5nI3CJ8LzX2quO8lWQxSgB2FNJdmYBot7IATmFFB--qr89Qx-br7cy0Jo4YW55wM_TB_SWM&usqp=CAc',
 ]
+
+const nameArr = [
+  '나이켈 에어맥스 테일 윈드 5SP',
+  '나이켈 에어 베이퍼 1402',
+  '나이켈 트레이닝 수트 상의',
+  '나이켈 트레이닝 수트 하의',
+  '나이켈 페가수스 트레일5',
+  '나이켈 SB 줌 블레이저',
+  '나이켈 에어맥스 테일윈드 7',
+  '나이켈 코스믹 유니티',
+  '나이켈 헤어밴드 리미티드',
+  '나이켈 줌 프릭 르브론F',
+  '나이켈 트릴비온 유니온',
+  '나이켈 스포티 레깅스 블랙',
+  '나이켈 에어 줌 테라 카이거9',
+  '나이켈 에어맥스 블로퍼 S',
+  '나이켈 트레이닝 팬츠 볼로바',
+]
+
+const categoryArr = {
+  primary: [['male', '남성']],
+  secondary: [['shoes', '신발'], ['clothes', '의류']],
+  tertiary: [['lifestyle', '라이프스타일'], ['running', '러닝'], ['training', '트레이닝 & 짐']],
+}
+
+const categoryObj = () => {
+  let obj = {};
+  for (let key in categoryArr) {
+    let nowCat = randomer(categoryArr[key]);
+    obj[key] = {
+      code: nowCat[0],
+      title: nowCat[1],
+    };
+  }
+  return obj;
+}
+
+const sizeObj = () => {
+  let obj = {};
+  for (let i = 230 ; i <= 290 ; i += 5) {
+    obj[i] = randomer(15) - 1;
+  }
+  return obj;
+}
+
+const colorArr = [
+  ['beige', '베이지'],
+  ['black', '검정색'],
+  ['blue', '파란색'],
+  ['brown', '갈색'],
+  ['gold', '금색'],
+  ['gray', '회색'],
+  ['green', '녹색'],
+  ['navy', '남색'],
+  ['pink', '분홍색'],
+  ['purple', '보라색'],
+  ['red', '빨간색'],
+  ['white', '흰색'],
+  ['yellow', '노란색'],
+]
+
+const colorObj = () => {
+  let obj = {
+    code: '',
+    title: '',
+    otherColors: [],
+  };
+  let count = randomer(5);
+  for (let i = 0 ; i < count ; i++) {
+    const nowColor = randomer(colorArr)
+    if (i = 0) {
+      obj.code = nowColor[0]
+      obj.title = nowColor[1]
+    }
+    else {
+      obj.otherColors[i-1] = {
+        id: 10000000 + randomer(1000),
+        code: nowColor[0],
+        title: nowColor[1]
+      }
+    }
+  }
+  return obj;
+}
+
+
+for (let i = 0 ; i < 150 ; i++) {
+  const itemObj =   {
+    id: 10000000 + randomer(1000),
+    images: [
+      randomer(imageArr),
+      randomer(imageArr),
+      randomer(imageArr),
+      randomer(imageArr),
+      randomer(imageArr),
+      randomer(imageArr),
+      randomer(imageArr),
+    ],
+    name: randomer(nameArr),
+    category: categoryObj(),
+    sizes: sizeObj(),
+    // colors: colorObj(),
+    colors: {
+      code: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: '/Images/default2.jpeg',
+          code: 'red',
+        },
+        {
+          id: 10001011,
+          image: '/Images/default.jpg',
+          code: 'gold',
+        },
+        {
+          id: 10001012,
+          image: '/Images/default2.jpeg',
+          code: 'navy',
+        },
+      ]
+    },
+    price: 89000 + (randomer(15) * 10000),
+    date: {
+      launched: 1610200000000 + randomer(7200000000),
+      updated: 1614200000000 + randomer(7200000000),
+    },
+  };
+  
+  itemsData.push(itemObj)
+}
 
 module.exports = itemsData;
 
 
 
 // let restsData = [];
-
-// const randomer = (src) => {
-//   if (typeof(src) === 'object') {
-//     return src[Math.floor(Math.random() * src.length)]
-//   }
-//   else {
-//     return Math.floor(Math.random() * src) + 1;
-//   }
-// }
+// let itemsData = [
+//   {
+//     id: 10001010,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'running',
+//         title: '러닝',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default2.jpeg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default2.jpeg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 129000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001001,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 0,
+//       235: 0,
+//       240: 0,
+//       245: 0,
+//       250: 0,
+//       255: 0,
+//       260: 0,
+//       265: 0,
+//       270: 0,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001002,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001003,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'running',
+//         title: '러닝',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001004,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001005,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001006,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001009,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001020,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+//   {
+//     id: 10001024,
+//     images: [
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//       '/Images/default.jpg',
+//     ],
+//     name: '나이키 에어맥스 테일 윈드 5SP',
+//     category: {
+//       primary: {
+//         code: 'male',
+//         title: '남성',
+//       },
+//       secondary: {
+//         code: 'shoes',
+//         title: '신발',
+//       },
+//       tertiary: {
+//         code: 'lifestyle',
+//         title: '라이프스타일',
+//       }
+//     },
+//     sizes: {
+//       230: 10,
+//       235: 10,
+//       240: 10,
+//       245: 10,
+//       250: 0,
+//       255: 10,
+//       260: 10,
+//       265: 0,
+//       270: 10,
+//       275: 0,
+//       280: 0,
+//     },
+//     colors: {
+//       code: 'white',
+//       title: '흰색',
+//       otherColors: [
+//         {
+//           id: 10001010,
+//           image: '/Images/default.jpg',
+//           code: 'red',
+//         },
+//         {
+//           id: 10001011,
+//           image: '/Images/default.jpg',
+//           code: 'gold',
+//         },
+//         {
+//           id: 10001012,
+//           image: '/Images/default.jpg',
+//           code: 'navy',
+//         },
+//       ]
+//     },
+//     price: 209000,
+//     date: {
+//       launched: 1615200000000,
+//       updated: 1617200000000,
+//     },
+//   },
+// ]

--- a/server/database/itemsData.js
+++ b/server/database/itemsData.js
@@ -12,16 +12,16 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
-        title: '라이프스타일',
+        code: 'running',
+        title: '러닝',
       }
     },
     sizes: {
@@ -38,27 +38,27 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default2.jpeg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default2.jpeg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
-    price: 209000,
+    price: 129000,
     date: {
       launched: 1615200000000,
       updated: 1617200000000,
@@ -77,15 +77,15 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -103,23 +103,23 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -142,15 +142,15 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -168,23 +168,23 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -207,16 +207,16 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
-        title: '라이프스타일',
+        code: 'running',
+        title: '러닝',
       }
     },
     sizes: {
@@ -233,23 +233,23 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -272,15 +272,15 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -298,23 +298,23 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -337,15 +337,15 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -363,23 +363,23 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
         },
       ]
     },
@@ -402,15 +402,15 @@ let itemsData = [
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
       primary: {
-        cord: 'male',
+        code: 'male',
         title: '남성',
       },
       secondary: {
-        cord: 'shoes',
+        code: 'shoes',
         title: '신발',
       },
       tertiary: {
-        cord: 'lifestyle',
+        code: 'lifestyle',
         title: '라이프스타일',
       }
     },
@@ -428,23 +428,218 @@ let itemsData = [
       280: 0,
     },
     colors: {
-      cord: 'white',
+      code: 'white',
       title: '흰색',
       otherColors: [
         {
           id: 10001010,
           image: '/Images/default.jpg',
-          cord: 'red',
+          code: 'red',
         },
         {
           id: 10001011,
           image: '/Images/default.jpg',
-          cord: 'gold',
+          code: 'gold',
         },
         {
           id: 10001012,
           image: '/Images/default.jpg',
-          cord: 'navy',
+          code: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001009,
+    images: [
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        code: 'male',
+        title: '남성',
+      },
+      secondary: {
+        code: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        code: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      code: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: '/Images/default.jpg',
+          code: 'red',
+        },
+        {
+          id: 10001011,
+          image: '/Images/default.jpg',
+          code: 'gold',
+        },
+        {
+          id: 10001012,
+          image: '/Images/default.jpg',
+          code: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001020,
+    images: [
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        code: 'male',
+        title: '남성',
+      },
+      secondary: {
+        code: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        code: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      code: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: '/Images/default.jpg',
+          code: 'red',
+        },
+        {
+          id: 10001011,
+          image: '/Images/default.jpg',
+          code: 'gold',
+        },
+        {
+          id: 10001012,
+          image: '/Images/default.jpg',
+          code: 'navy',
+        },
+      ]
+    },
+    price: 209000,
+    date: {
+      launched: 1615200000000,
+      updated: 1617200000000,
+    },
+  },
+  {
+    id: 10001024,
+    images: [
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+    ],
+    name: '나이키 에어맥스 테일 윈드 5SP',
+    category: {
+      primary: {
+        code: 'male',
+        title: '남성',
+      },
+      secondary: {
+        code: 'shoes',
+        title: '신발',
+      },
+      tertiary: {
+        code: 'lifestyle',
+        title: '라이프스타일',
+      }
+    },
+    sizes: {
+      230: 10,
+      235: 10,
+      240: 10,
+      245: 10,
+      250: 0,
+      255: 10,
+      260: 10,
+      265: 0,
+      270: 10,
+      275: 0,
+      280: 0,
+    },
+    colors: {
+      code: 'white',
+      title: '흰색',
+      otherColors: [
+        {
+          id: 10001010,
+          image: '/Images/default.jpg',
+          code: 'red',
+        },
+        {
+          id: 10001011,
+          image: '/Images/default.jpg',
+          code: 'gold',
+        },
+        {
+          id: 10001012,
+          image: '/Images/default.jpg',
+          code: 'navy',
         },
       ]
     },

--- a/server/database/itemsData.js
+++ b/server/database/itemsData.js
@@ -2,12 +2,12 @@ let itemsData = [
   {
     id: 10001010,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -43,17 +43,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default2.jpeg',
+          image: '/Images/default2.jpeg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default2.jpeg',
+          image: '/Images/default2.jpeg',
           cord: 'navy',
         },
       ]
@@ -67,12 +67,12 @@ let itemsData = [
   {
     id: 10001001,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -108,17 +108,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -132,12 +132,12 @@ let itemsData = [
   {
     id: 10001002,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -173,17 +173,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -197,12 +197,12 @@ let itemsData = [
   {
     id: 10001003,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -238,17 +238,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -262,12 +262,12 @@ let itemsData = [
   {
     id: 10001004,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -303,17 +303,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -327,12 +327,12 @@ let itemsData = [
   {
     id: 10001005,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -368,17 +368,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]
@@ -392,12 +392,12 @@ let itemsData = [
   {
     id: 10001006,
     images: [
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
-      './Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
+      '/Images/default.jpg',
     ],
     name: '나이키 에어맥스 테일 윈드 5SP',
     category: {
@@ -433,17 +433,17 @@ let itemsData = [
       otherColors: [
         {
           id: 10001010,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'red',
         },
         {
           id: 10001011,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'gold',
         },
         {
           id: 10001012,
-          image: './Images/default.jpg',
+          image: '/Images/default.jpg',
           cord: 'navy',
         },
       ]

--- a/server/database/itemsData.js
+++ b/server/database/itemsData.js
@@ -59,7 +59,7 @@ const nameArr = [
 
 const categoryArr = {
   primary: [['male', '남성']],
-  secondary: [['shoes', '신발'], ['clothes', '의류']],
+  secondary: [['shoes', '신발'],],
   tertiary: [['lifestyle', '라이프스타일'], ['running', '러닝'], ['training', '트레이닝 & 짐']],
 }
 
@@ -108,7 +108,7 @@ const colorObj = () => {
   let count = randomer(5);
   for (let i = 0 ; i < count ; i++) {
     const nowColor = randomer(colorArr)
-    if (i = 0) {
+    if (i === 0) {
       obj.code = nowColor[0]
       obj.title = nowColor[1]
     }
@@ -116,7 +116,8 @@ const colorObj = () => {
       obj.otherColors[i-1] = {
         id: 10000000 + randomer(1000),
         code: nowColor[0],
-        title: nowColor[1]
+        title: nowColor[1],
+        image: randomer(imageArr),
       }
     }
   }
@@ -139,28 +140,7 @@ for (let i = 0 ; i < 150 ; i++) {
     name: randomer(nameArr),
     category: categoryObj(),
     sizes: sizeObj(),
-    // colors: colorObj(),
-    colors: {
-      code: 'white',
-      title: '흰색',
-      otherColors: [
-        {
-          id: 10001010,
-          image: '/Images/default2.jpeg',
-          code: 'red',
-        },
-        {
-          id: 10001011,
-          image: '/Images/default.jpg',
-          code: 'gold',
-        },
-        {
-          id: 10001012,
-          image: '/Images/default2.jpeg',
-          code: 'navy',
-        },
-      ]
-    },
+    colors: colorObj(),
     price: 89000 + (randomer(15) * 10000),
     date: {
       launched: 1610200000000 + randomer(7200000000),

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -2,21 +2,17 @@ var express = require('express');
 var router = express.Router();
 
 const itemsData = require('../database/itemsData');
-const LIMIT = 10;
 
 // List Router
 router.get('/:primary/:secondary', function(req, res) {
   let itemList = filterByParams(itemsData, req.params)
-  itemList = sliceList(itemList); 
   res.json({
     itemList
   });
 });
 
 router.get('/:primary/:secondary/:tertiary', function(req, res) {
-  console.log(itemsData);
   let itemList = filterByParams(itemsData, req.params);
-  itemList = sliceList(itemList);
   res.json({
     itemList
   });
@@ -34,10 +30,10 @@ const filterByParams = (list, params) => {
   return newList;
 }
 
-const sliceList = (list) => {
-  const offset = 0 * LIMIT;
-  return list.slice(offset, offset + LIMIT);
-}
+// const sliceList = (list) => {
+//   const offset = 0 * LIMIT;
+//   return list.slice(offset, offset + LIMIT);
+// }
 
 // List Functions
 const filterByQuery = (filter, list) => {

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -2,17 +2,21 @@ var express = require('express');
 var router = express.Router();
 
 const itemsData = require('../database/itemsData');
+const LIMIT = 10;
 
 // List Router
 router.get('/:primary/:secondary', function(req, res) {
   let itemList = filterByParams(itemsData, req.params)
+  itemList = sliceList(itemList); 
   res.json({
     itemList
   });
 });
 
 router.get('/:primary/:secondary/:tertiary', function(req, res) {
-  let itemList = filterByParams(itemsData, req.params)
+  console.log(itemsData);
+  let itemList = filterByParams(itemsData, req.params);
+  itemList = sliceList(itemList);
   res.json({
     itemList
   });
@@ -28,6 +32,11 @@ const filterByParams = (list, params) => {
     newList = newList.filter((item) => item.category.tertiary.code === tertiary);
   }
   return newList;
+}
+
+const sliceList = (list) => {
+  const offset = 0 * LIMIT;
+  return list.slice(offset, offset + LIMIT);
 }
 
 // List Functions

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -5,8 +5,6 @@ const itemsData = require('../database/itemsData');
 
 // List Router
 router.get('/:primary/:secondary/:tertiary', function(req, res) {
-  console.log(req.params)
-  console.log(req.query)
   const { primary, secondary, tertiary } = req.params
   let itemList = itemsData.filter((item) => {
     item.category.primary === primary &&
@@ -14,6 +12,7 @@ router.get('/:primary/:secondary/:tertiary', function(req, res) {
     item.category.tertiary === tertiary
   })
   itemList = itemList.slice(0, 20);
+  console.log(itemList);
   res.json(itemList);
 });
 

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -4,17 +4,31 @@ var router = express.Router();
 const itemsData = require('../database/itemsData');
 
 // List Router
-router.get('/:primary/:secondary/:tertiary', function(req, res) {
-  const { primary, secondary, tertiary } = req.params
-  let itemList = itemsData.filter((item) => {
-    item.category.primary === primary &&
-    item.category.secondary === secondary &&
-    item.category.tertiary === tertiary
-  })
-  itemList = itemList.slice(0, 20);
-  console.log(itemList);
-  res.json(itemList);
+router.get('/:primary/:secondary', function(req, res) {
+  let itemList = filterByParams(itemsData, req.params)
+  res.json({
+    itemList
+  });
 });
+
+router.get('/:primary/:secondary/:tertiary', function(req, res) {
+  let itemList = filterByParams(itemsData, req.params)
+  res.json({
+    itemList
+  });
+});
+
+const filterByParams = (list, params) => {
+  const { primary, secondary, tertiary } = params;
+  let newList = list.filter((item) => {
+    return item.category.primary.code === primary 
+      && item.category.secondary.code === secondary;
+  })
+  if (tertiary) {
+    newList = newList.filter((item) => item.category.tertiary.code === tertiary);
+  }
+  return newList;
+}
 
 // List Functions
 const filterByQuery = (filter, list) => {


### PR DESCRIPTION
## 개요
itemList 상품리스트 데이터 프론트(List 페이지)-백(itemRouter 라우터) 연동 테스트

## 수정내용
- `<NavCategories>` 링크 Path Parameter 연동, `<List>` 페이지 라우팅 시 pathname 값으로 서버패칭(dispatch)
- Redux 관련수정 : Reducer, Action, Saga 제작. List 페이지 렌더링 시 현재 path값에 따른 path parameter로 request
- Infinite Scroll : 스크롤 바닥에 닿을 시, 디스패치 재실행. 전체 데이터를 round state에 1씩 더하면서 클라이언트에서 분할한 페이지네이션 우선 구현
- Sorting : Sort 모드("new" 신상품, "expensive" 가격 높은순, "cheap" 가격 낮은순)에 따른 Action - Reducer 현재 itemList 소팅
- Server(router) : path parameter(category 1~3) 에 따른 itemsData 필터링 후 response
- Server(DB) : random 로직에 따른 150개 임의 데이터 제작

## 특이사항
- 상세 페이지 제작에 따른 item 데이터 뷰 추가/수정 소요 있음
- 좌측 키워드, 색깔, 신발 사이즈 등 필터링 시 로직 추후 구현예정
- pagination을 PATCH 등으로, round를 req.body에 담아 서버에서 분할해서 보내는 방법 테스트 필요
- `<Detail>` 상세 페이지 데이터 연동 테스트를 위한 선 merge

## 체크리스트
- [x] Main branch 최신화(merge)를 진행했는가?
- [x] 컴포넌트에 필요한 UI구현에 이상이 없는가?
- [x] 기능구현에 필요한 테스트를 진행하였고 이상이 없는가?
- [x] 최종 Push 전 코드 리펙토링을 진행하였는가? (불필요 콘솔 및 주석, 컨벤션, 코드개선 등) 
