### PR TITLE
[PJT3/Nikel] Custom Hooks : useScroll 커스텀 훅을 통한 컴포넌트 제어

### DIFF
--- a/client/src/Components/Header/components/HeaderNavbar.jsx
+++ b/client/src/Components/Header/components/HeaderNavbar.jsx
@@ -1,34 +1,23 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { Linker } from '../../../Common/StyledCommon';
-import { flexAlign, flexBetween } from '../../../Styles/theme';
+import useScroll from '../../../Hooks/useScroll';
 import NavMenu from './Navbar/NavMenu';
 import NavTools from './Navbar/NavTools';
 import NavCategories from './Navbar/NavCategories';
+import { flexAlign, flexBetween } from '../../../Styles/theme';
 
 const HeaderNavbar = ({ setSearchOn }) => {
-  const [pageY, setPageY] = useState(0);
-  const [navHide, setNavHide] = useState(false);
   const [navFocus, setNavFocus] = useState(0);
   const [focusChange, setFocusChange] = useState(false);
-
-  const handleScroll = useCallback(() => {
-    const { pageYOffset } = window;
-    setPageY(pageYOffset);
-    setNavHide(pageYOffset > 36 && pageYOffset > pageY);
-  }, [pageY]);
+  const scrollBelow = useScroll();
 
   const exitCategories = () => {
     setNavFocus(0);
   }
 
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [pageY, handleScroll])
-
   return (
-    <Headernavbar isFixed={window.pageYOffset > 36} isHide={navHide}>
+    <Headernavbar isFixed={window.pageYOffset > 36} isHide={scrollBelow}>
       <NavWrapper>
         <NavLogo to="/">
           <img src="/Images/logo-nike.png" alt="logo-nike" onMouseEnter={exitCategories}/>

--- a/client/src/Containers/List/List.jsx
+++ b/client/src/Containers/List/List.jsx
@@ -24,8 +24,8 @@ const List = () => {
   }, [itemListState])
 
   const handleScroll = useCallback(() => {
-    const { pageYOffset } = window;
-    setIsFixed(pageYOffset > 37)
+    const { Offset } = window;
+    setIsFixed(Offset > 37)
 
     const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
     if (scrollTop + clientHeight >= scrollHeight) {

--- a/client/src/Containers/List/components/ListHeader.jsx
+++ b/client/src/Containers/List/components/ListHeader.jsx
@@ -2,33 +2,22 @@ import React, { useState, useEffect, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { sortItemList } from '../../../Store/Action/itemListAction';
+import useScroll from '../../../Hooks/useScroll';
 import { Button } from '../../../Common/StyledCommon';
 import { flexCenter, flexBetween } from '../../../Styles/theme';
 import { FaList } from 'react-icons/fa';
 import { IoIosArrowUp } from 'react-icons/io';
 
 const ListHeader = ({ isFixed, filterOn, setFilterOn, sortMode, setSortMode }) => {
-  const [pageY, setPageY] = useState(0);
-  const [headerUp, setHeaderUp] = useState(false);
   const [sortOn, setSortOn] = useState(false);
   const dispatch = useDispatch();
+  const scrollBelow = useScroll();
 
   const sortModeList = {
     'new': '신상품순',
     'expensive': '높은 가격순',
     'cheap': '낮은 가격순',
   };
-
-  const handleScroll = useCallback(() => {
-    const { pageYOffset } = window;
-    setPageY(pageYOffset);
-    setHeaderUp(pageYOffset > 36 && pageYOffset > pageY);
-  }, [pageY]);
-  
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [handleScroll])
 
   const changeSortMode = (mode) => {
     setSortMode(mode)
@@ -37,7 +26,7 @@ const ListHeader = ({ isFixed, filterOn, setFilterOn, sortMode, setSortMode }) =
   }
 
   return (
-    <Listheader isFixed={isFixed} isUp={headerUp} >
+    <Listheader isFixed={isFixed} isHide={scrollBelow} >
       <div>
         <p>Men</p>
         <h2>Men's 신발</h2>
@@ -68,7 +57,7 @@ const Listheader = styled.header`
   width: 100%;
   padding: 30px 48px;
   background: #ffffff;
-  transform: ${({ isUp }) => isUp ? 'translateY(-60px)': 'translateY(00px)'};
+  transform: ${({ isHide }) => isHide ? 'translateY(-60px)': 'translateY(00px)'};
   transition: ${({ theme }) => theme.transition};
   z-index: ${({ theme }) => theme.z_Navbar_under};
 
@@ -93,7 +82,6 @@ const Listheader = styled.header`
     `
     : css`
       position: relative;
-
       div {
         p {
           margin: 0 0 10px;

--- a/client/src/Hooks/useScroll.jsx
+++ b/client/src/Hooks/useScroll.jsx
@@ -1,0 +1,23 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const headerHeight = 36;
+
+const useScroll = () => {
+  const [pageY, setPageY] = useState(0);
+  const [isBelow, setIsBelow] = useState(false);
+  
+  const handleScroll = useCallback(() => {
+    const { pageYOffset } = window;
+    setPageY(pageYOffset);
+    setIsBelow(pageYOffset > headerHeight && pageYOffset > pageY);
+  }, [pageY])
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+  
+  return isBelow;
+}
+
+export default useScroll;


### PR DESCRIPTION
## 개요
`<HeaderNavbar>`, `<ListHeader>` 두 헤더의 스크롤 방향에 따른 translateY 제어를 위한 useScroll 커스텀 훅 제작

## 수정내용
- src > Hooks 디렉토리 생성 및 useScroll.js 파일 내 커스텀 훅 제작
- `<HeaderNavbar>`, `<ListHeader>`컴포넌트에서 중복되던 pageYOffset 값 증감에 따른 true/false 상태반환 Hooks 로 제작

## 특이사항
- 없음

## 체크리스트
- [x] Main branch 최신화(merge)를 진행했는가?
- [x] 컴포넌트에 필요한 UI구현에 이상이 없는가?
- [x] 기능구현에 필요한 테스트를 진행하였고 이상이 없는가?
- [x] 최종 Push 전 코드 리펙토링을 진행하였는가? (불필요 콘솔 및 주석, 컨벤션, 코드개선 등) 
